### PR TITLE
FIX Always show login credentials on Security_login template

### DIFF
--- a/mysite/templates/SilverStripe/Security/Security_login.ss
+++ b/mysite/templates/SilverStripe/Security/Security_login.ss
@@ -39,11 +39,8 @@ Change it, enhance it and most importantly enjoy it!
             <div class="content-container unit size3of4 lastUnit">
                 <article>
                     <h1>$Title</h1>
-                    <% if $Action = 'login' %>
-                        <% if $CurrentMember %><% else %>
-                            <div class="content">Please login using email "admin" and password: "password"</div><% end_if %>
-                    <% else %>
-                        <div class="content">$Content</div>
+                    <% if not $CurrentMember %>
+                        <div class="content">Please login using email "admin" and password: "password"</div>
                     <% end_if %>
                 </article>
                 $Form


### PR DESCRIPTION
`$Action` isn't available in security templates by the look of it, since `Security::renderWrappedController` returns a customised controller. @tractorcow do you think we should add this to Security manually?

Anyway - this template is only used for the login action so we don't need the condition.